### PR TITLE
Context isolation

### DIFF
--- a/.codesandbox/templates/vanilla/src/testcases/simpleTextbox.ts
+++ b/.codesandbox/templates/vanilla/src/testcases/simpleTextbox.ts
@@ -37,9 +37,19 @@ export function testCase(canvas: fabric.Canvas) {
     height: 50,
     left: 0,
     top: 100,
+    paintFirst: 'stroke',
+    shadow: new fabric.Shadow({
+      affectStroke: true,
+      blur: 5,
+      offsetX: 20,
+      offsetY: 20,
+      // nonScaling: true,
+      color: 'red',
+    }),
   });
   canvas.centerObject(text);
   canvas.centerObject(rect);
+  canvas.preserveObjectStacking = true;
   const group = new fabric.Group([rect, text], {
     subTargetCheck: true,
     interactive: true,
@@ -61,6 +71,9 @@ export function testCase(canvas: fabric.Canvas) {
           opacity: value,
         });
         text.set({ dirty: true });
+        rect.shadow!.offsetX = 20 * (value + 1);
+        rect.shadow!.blur = 20 * value;
+        rect.set({ dirty: true });
         canvas.renderAll();
       },
       onComplete: () => animate(!toState),

--- a/.codesandbox/templates/vanilla/src/testcases/simpleTextbox.ts
+++ b/.codesandbox/templates/vanilla/src/testcases/simpleTextbox.ts
@@ -7,6 +7,7 @@ export function testCase(canvas: fabric.Canvas) {
     splitByGrapheme: true,
     width: 200,
     top: 20,
+    backgroundColor: 'yellow',
     styles: fabric.util.stylesFromArray(
       [
         {
@@ -20,21 +21,68 @@ export function testCase(canvas: fabric.Canvas) {
       ],
       textValue
     ),
+    clipPath: new fabric.Circle({
+      radius: 50,
+      originX: 'center',
+      originY: 'center',
+      scaleX: 2,
+      inverted: true,
+      fill: 'blue',
+      // opacity: 0.4,
+    }),
   });
-  canvas.add(text);
-  canvas.centerObjectH(text);
+  const rect = new fabric.Rect({
+    fill: 'blue',
+    width: 100,
+    height: 50,
+    left: 0,
+    top: 100,
+  });
+  canvas.centerObject(text);
+  canvas.centerObject(rect);
+  const group = new fabric.Group([rect, text], {
+    subTargetCheck: true,
+    interactive: true,
+    clipPath: new fabric.Circle({
+      radius: 100,
+      originX: 'center',
+      originY: 'center',
+    }),
+  });
+  canvas.add(group);
+
   function animate(toState) {
-    text.animate(
-      { scaleX: Math.max(toState, 0.1) * 2 },
-      {
-        onChange: () => canvas.renderAll(),
-        onComplete: () => animate(!toState),
-        duration: 1000,
-        easing: toState
-          ? fabric.util.ease.easeInOutQuad
-          : fabric.util.ease.easeInOutSine,
-      }
-    );
+    fabric.util.animate({
+      startValue: 1 - Number(toState),
+      endValue: Number(toState),
+      onChange: (value) => {
+        text.clipPath?.set({
+          scaleX: Math.max(value, 0.1) * 2,
+          opacity: value,
+        });
+        text.set({ dirty: true });
+        canvas.renderAll();
+      },
+      onComplete: () => animate(!toState),
+      duration: 150,
+      easing: toState
+        ? fabric.util.ease.easeInOutQuad
+        : fabric.util.ease.easeInOutSine,
+    });
+    // text.clipPath!.animate(
+    //   {
+    //     scaleX: Math.max(Number(toState), 0.1) * 2,
+    //     opacity: Number(toState),
+    //   },
+    //   {
+    //     onChange: () => canvas.requestRenderAll(),
+    //     onComplete: () => animate(!toState),
+    //     duration: 150,
+    //     easing: toState
+    //       ? fabric.util.ease.easeInOutQuad
+    //       : fabric.util.ease.easeInOutSine,
+    //   }
+    // );
   }
-  // animate(1);
+  animate(1);
 }

--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -33,6 +33,7 @@
 - chore(TS): use consistent and improved types for getDefaults and ownDefaults [#9698](https://github.com/fabricjs/fabric.js/pull/9698)
 - fix(SVGParser): Don't crash on nested CSS at-rules [#9707](https://github.com/fabricjs/fabric.js/pull/9707)
 - perf(): measuring canvas size [#9697](https://github.com/fabricjs/fabric.js/pull/9697)
+- WIP fix(): context isolation [#9693](https://github.com/fabricjs/fabric.js/pull/9693)
 - chore(TS): Add type for options in toCanvasElement and toDataUrl [#9673](https://github.com/fabricjs/fabric.js/pull/9673)
 - ci(): add source map support to node sandbox [#9686](https://github.com/fabricjs/fabric.js/pull/9686)
 - fix(Canvas): Correct type mainTouchId initialization [#9684](https://github.com/fabricjs/fabric.js/pull/9684)

--- a/src/canvas/CanvasProvider.ts
+++ b/src/canvas/CanvasProvider.ts
@@ -3,38 +3,110 @@ import { TSize } from '../typedefs';
 import { createCanvasElement } from '../util/misc/dom';
 
 type RenderingContextType = '2d' | 'webgl';
-type ContextState = {
-  __type: RenderingContextType;
-  __locked: boolean;
-  release(): void;
-};
+
 type RenderingContextProviderMap = {
-  '2d': CanvasRenderingContext2D;
-  // bitmaprenderer:ImageBitmapRenderingContext
-  webgl: WebGLRenderingContext;
-  // webgl2: WebGL2RenderingContext
+  '2d': {
+    ctx: CanvasRenderingContext2D;
+    options: CanvasRenderingContext2DSettings;
+  };
+  webgl: { ctx: WebGLRenderingContext; options: WebGLContextAttributes };
+  // webgl2: { ctx: WebGL2RenderingContext; options: WebGLContextAttributes };
+  // bitmaprenderer: {
+  //   ctx: ImageBitmapRenderingContext;
+  //   options: ImageBitmapRenderingContextSettings;
+  // };
 };
 
 type RenderingContext<T extends RenderingContextType = RenderingContextType> =
-  RenderingContextProviderMap[T];
+  RenderingContextProviderMap[T]['ctx'];
+
+type RenderingContextOptions<
+  T extends RenderingContextType = RenderingContextType
+> = RenderingContextProviderMap[T]['options'];
 
 type RenderingContextProvider<
   T extends RenderingContextType = RenderingContextType
-> = (type: T, options?: any) => RenderingContext<T> | null;
+> = (
+  type: T,
+  options?: RenderingContextOptions<T>
+) => RenderingContext<T> | null;
 
 type StatefulRenderingContext<
   T extends RenderingContextType = RenderingContextType
-> = RenderingContext<T> & ContextState;
+> = RenderingContext<T> & {
+  __type: T;
+  __options: RenderingContextOptions<T>;
+  __locked: boolean;
+  release(): void;
+};
+
+const isEqualOrDefault = <T>(
+  a: T | undefined,
+  b: T | undefined,
+  defaultValue: T
+) => a === b || (!a && b === defaultValue) || (a === defaultValue && !b);
 
 class CanvasProvider {
+  static compare2dOptions(
+    a: RenderingContextOptions<'2d'> | undefined,
+    b: RenderingContextOptions<'2d'> | undefined
+  ) {
+    return (
+      a === b ||
+      isEqualOrDefault(a?.alpha, b?.alpha, false) ||
+      isEqualOrDefault(a?.colorSpace, b?.colorSpace, 'srgb') ||
+      isEqualOrDefault(a?.desynchronized, b?.desynchronized, false) ||
+      isEqualOrDefault(a?.willReadFrequently, b?.willReadFrequently, false)
+    );
+  }
+
+  static compareWebGLOptions(
+    a: RenderingContextOptions<'webgl'> | undefined,
+    b: RenderingContextOptions<'webgl'> | undefined
+  ) {
+    return (
+      a === b ||
+      isEqualOrDefault(a?.alpha, b?.alpha, false) ||
+      isEqualOrDefault(a?.antialias, b?.antialias, false) ||
+      isEqualOrDefault(a?.depth, b?.depth, false) ||
+      isEqualOrDefault(a?.desynchronized, b?.depth, false) ||
+      isEqualOrDefault(
+        a?.failIfMajorPerformanceCaveat,
+        b?.failIfMajorPerformanceCaveat,
+        false
+      ) ||
+      isEqualOrDefault(a?.powerPreference, b?.powerPreference, 'default') ||
+      isEqualOrDefault(a?.premultipliedAlpha, b?.premultipliedAlpha, false) ||
+      isEqualOrDefault(
+        a?.preserveDrawingBuffer,
+        b?.preserveDrawingBuffer,
+        false
+      ) ||
+      isEqualOrDefault(a?.stencil, b?.stencil, false)
+    );
+  }
+
+  static compareOptions<T extends RenderingContextType>(
+    type: T,
+    a: RenderingContextOptions<T> | undefined,
+    b: RenderingContextOptions<T> | undefined
+  ) {
+    switch (type) {
+      case '2d':
+        return this.compare2dOptions(a, b);
+      case 'webgl':
+        return this.compareWebGLOptions(a, b);
+    }
+  }
+
   private builder: RenderingContextProvider = <T extends RenderingContextType>(
     type: T,
-    options?: any
+    options?: RenderingContextOptions<T>
   ) => {
     return createCanvasElement().getContext(
       type,
       options
-    ) as RenderingContextProviderMap[T];
+    ) as RenderingContext<T>;
   };
   private stack: StatefulRenderingContext[] = [];
   private pruned: StatefulRenderingContext[] = [];
@@ -44,10 +116,19 @@ class CanvasProvider {
     this.builder = builder;
   }
 
-  private create<T extends RenderingContextType>(type: T) {
-    const value = Object.defineProperties(this.builder(type), {
+  public create<T extends RenderingContextType>(
+    type: T,
+    options?: RenderingContextOptions<T>
+  ) {
+    const value = Object.defineProperties(this.builder(type, options), {
       __type: {
         value: type,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      },
+      __options: {
+        value: options,
         enumerable: false,
         configurable: false,
         writable: false,
@@ -71,14 +152,20 @@ class CanvasProvider {
     return value;
   }
 
-  public request<T extends RenderingContextType = '2d'>({
-    type = '2d' as T,
-    width,
-    height,
-  }: { type?: T } & TSize): StatefulRenderingContext<T> {
+  public request<T extends RenderingContextType = '2d'>(
+    { type = '2d' as T, width, height }: { type?: T } & TSize,
+    options?: RenderingContextOptions<T>
+  ): StatefulRenderingContext<T> {
     const ctx = (this.stack.find(
-      (item) => !item.__locked && item.__type === type
-    ) || this.create(type)) as StatefulRenderingContext<T>;
+      (item) =>
+        !item.__locked &&
+        item.__type === type &&
+        (this.constructor as typeof CanvasProvider).compareOptions(
+          type,
+          item.__options,
+          options
+        )
+    ) || this.create(type, options)) as StatefulRenderingContext<T>;
     ctx.__locked = true;
     this.isPruning && this.pruned.push(ctx);
     const { canvas } = ctx;

--- a/src/canvas/CanvasProvider.ts
+++ b/src/canvas/CanvasProvider.ts
@@ -1,0 +1,117 @@
+import { getEnv } from '../env';
+import { TSize } from '../typedefs';
+import { createCanvasElement } from '../util/misc/dom';
+
+type RenderingContextType = '2d' | 'webgl';
+type ContextState = {
+  __type: RenderingContextType;
+  __locked: boolean;
+  release(): void;
+};
+type RenderingContextProviderMap = {
+  '2d': CanvasRenderingContext2D;
+  // bitmaprenderer:ImageBitmapRenderingContext
+  webgl: WebGLRenderingContext;
+  // webgl2: WebGL2RenderingContext
+};
+
+type RenderingContext<T extends RenderingContextType = RenderingContextType> =
+  RenderingContextProviderMap[T];
+
+type RenderingContextProvider<
+  T extends RenderingContextType = RenderingContextType
+> = (type: T, options?: any) => RenderingContext<T> | null;
+
+type StatefulRenderingContext<
+  T extends RenderingContextType = RenderingContextType
+> = RenderingContext<T> & ContextState;
+
+class CanvasProvider {
+  private builder: RenderingContextProvider = <T extends RenderingContextType>(
+    type: T,
+    options?: any
+  ) => {
+    return createCanvasElement().getContext(
+      type,
+      options
+    ) as RenderingContextProviderMap[T];
+  };
+  private stack: StatefulRenderingContext[] = [];
+  private pruned: StatefulRenderingContext[] = [];
+  private isPruning = false;
+
+  public registerBuilder(builder: RenderingContextProvider) {
+    this.builder = builder;
+  }
+
+  private create<T extends RenderingContextType>(type: T) {
+    const value = Object.defineProperties(this.builder(type), {
+      __type: {
+        value: type,
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      },
+      __locked: {
+        value: false,
+        enumerable: false,
+        configurable: false,
+        writable: true,
+      },
+      release: {
+        value() {
+          this.__locked = false;
+        },
+        enumerable: false,
+        configurable: false,
+        writable: false,
+      },
+    }) as StatefulRenderingContext<T>;
+    this.stack.push(value);
+    return value;
+  }
+
+  public request<T extends RenderingContextType = '2d'>({
+    type = '2d' as T,
+    width,
+    height,
+  }: { type?: T } & TSize): StatefulRenderingContext<T> {
+    const ctx = (this.stack.find(
+      (item) => !item.__locked && item.__type === type
+    ) || this.create(type)) as StatefulRenderingContext<T>;
+    ctx.__locked = true;
+    this.isPruning && this.pruned.push(ctx);
+    const { canvas } = ctx;
+    canvas.width = width;
+    canvas.height = height;
+    return ctx;
+  }
+
+  public release(ctx: RenderingContext) {
+    const found = this.stack.find((c) => c === ctx);
+    found && (found.__locked = false);
+  }
+
+  public beginPruning() {
+    this.isPruning = true;
+    this.pruned = [];
+  }
+
+  public prune() {
+    this.stack
+      .filter((ctx) => !this.pruned.includes(ctx))
+      .forEach((ctx) => getEnv().dispose(ctx.canvas));
+    this.stack = this.pruned;
+    this.pruned = [];
+    this.isPruning = false;
+  }
+
+  public dispose() {
+    this.stack.map((ctx) => getEnv().dispose(ctx.canvas));
+    this.stack = [];
+    this.pruned = [];
+    this.isPruning = false;
+  }
+}
+
+export const canvasProvider = new CanvasProvider();

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -44,6 +44,7 @@ import type { StaticCanvasOptions } from './StaticCanvasOptions';
 import { staticCanvasDefaults } from './StaticCanvasOptions';
 import { log, FabricError } from '../util/internals/console';
 import { getDevicePixelRatio } from '../env';
+import { canvasProvider } from './CanvasProvider';
 
 /**
  * Having both options in TCanvasSizeOptions set to true transform the call in a calcOffset
@@ -567,6 +568,8 @@ export class StaticCanvas<
       return;
     }
 
+    canvasProvider.lock();
+
     const v = this.viewportTransform,
       path = this.clipPath;
     this.calcViewportBoundaries();
@@ -595,6 +598,8 @@ export class StaticCanvas<
       this.drawControls(ctx);
     }
     this.fire('after:render', { ctx });
+
+    canvasProvider.unlock();
 
     if (this.__cleanupTask) {
       this.__cleanupTask();

--- a/src/canvas/StaticCanvas.ts
+++ b/src/canvas/StaticCanvas.ts
@@ -587,11 +587,8 @@ export class StaticCanvas<
     }
     if (path) {
       path._set('canvas', this);
-      // needed to setup a couple of variables
-      path.shouldCache();
       path._transformDone = true;
-      path.renderCache({ forClipping: true });
-      this.drawClipPathOnCanvas(ctx, path as TCachedFabricObject);
+      path.renderInIsolation(ctx, true);
     }
     this._renderOverlay(ctx);
     if (this.controlsAboveOverlay) {

--- a/src/env/types.ts
+++ b/src/env/types.ts
@@ -11,6 +11,6 @@ export type TFabricEnv = {
   readonly window: (Window & typeof globalThis) | DOMWindow;
   readonly isTouchSupported: boolean;
   WebGLProbe: GLProbe;
-  dispose(element: Element): void;
+  dispose(element: Element | OffscreenCanvas): void;
   copyPasteData: TCopyPasteData;
 };

--- a/src/shapes/ActiveSelection.ts
+++ b/src/shapes/ActiveSelection.ts
@@ -217,14 +217,6 @@ export class ActiveSelection extends Group {
   }
 
   /**
-   * Check if this group or its parent group are caching, recursively up
-   * @return {Boolean}
-   */
-  isOnACache() {
-    return false;
-  }
-
-  /**
    * Renders controls and borders for the object
    * @param {CanvasRenderingContext2D} ctx Context to render on
    * @param {Object} [styleOverride] properties to override the object style

--- a/src/shapes/Group.ts
+++ b/src/shapes/Group.ts
@@ -423,55 +423,17 @@ export class Group
   }
 
   /**
-   * Decide if the object should cache or not. Create its own cache level
-   * needsItsOwnCache should be used when the object drawing method requires
-   * a cache step. None of the fabric classes requires it.
-   * Generally you do not cache objects in groups because the group is already cached.
-   * @return {Boolean}
+   * Group should always render in isolation to respect {@link CanvasRenderingContext2D#globalCompositeOperation}
    */
-  shouldCache() {
-    const ownCache = FabricObject.prototype.shouldCache.call(this);
-    if (ownCache) {
-      for (let i = 0; i < this._objects.length; i++) {
-        if (this._objects[i].willDrawShadow()) {
-          this.ownCaching = false;
-          return false;
-        }
-      }
-    }
-    return ownCache;
-  }
-
-  /**
-   * Check if this object or a child object will cast a shadow
-   * @return {Boolean}
-   */
-  willDrawShadow() {
-    if (super.willDrawShadow()) {
-      return true;
-    }
-    for (let i = 0; i < this._objects.length; i++) {
-      if (this._objects[i].willDrawShadow()) {
-        return true;
-      }
-    }
-    return false;
-  }
-
-  /**
-   * Check if instance or its group are caching, recursively up
-   * @return {Boolean}
-   */
-  isOnACache(): boolean {
-    return this.ownCaching || (!!this.parent && this.parent.isOnACache());
+  requiresContextIsolation() {
+    return true;
   }
 
   /**
    * Execute the drawing operation for an object on a specified context
    * @param {CanvasRenderingContext2D} ctx Context to render on
    */
-  drawObject(ctx: CanvasRenderingContext2D) {
-    this._renderBackground(ctx);
+  _render(ctx: CanvasRenderingContext2D) {
     for (let i = 0; i < this._objects.length; i++) {
       // TODO: handle rendering edge case somehow
       if (
@@ -486,7 +448,6 @@ export class Group
         this._objects[i].render(ctx);
       }
     }
-    this._drawClipPath(ctx, this.clipPath);
   }
 
   /**

--- a/src/shapes/Image.ts
+++ b/src/shapes/Image.ts
@@ -607,21 +607,6 @@ export class FabricImage<
     super.drawCacheOnCanvas(ctx);
   }
 
-  /**
-   * Decide if the object should cache or not. Create its own cache level
-   * needsItsOwnCache should be used when the object drawing method requires
-   * a cache step. None of the fabric classes requires it.
-   * Generally you do not cache objects in groups because the group outside is cached.
-   * This is the special image version where we would like to avoid caching where possible.
-   * Essentially images do not benefit from caching. They may require caching, and in that
-   * case we do it. Also caching an image usually ends in a loss of details.
-   * A full performance audit should be done.
-   * @return {Boolean}
-   */
-  shouldCache() {
-    return this.needsItsOwnCache();
-  }
-
   _renderFill(ctx: CanvasRenderingContext2D) {
     const elementToDraw = this._element;
     if (!elementToDraw) {

--- a/src/shapes/Object/Object.spec.ts
+++ b/src/shapes/Object/Object.spec.ts
@@ -77,33 +77,33 @@ describe('Object', () => {
   describe('needsItsOwnCache', () => {
     it('returns false for default values', () => {
       const rect = new Rect({ width: 100, height: 100 });
-      expect(rect.needsItsOwnCache()).toBe(false);
+      expect(rect.requiresContextIsolation()).toBe(false);
     });
     it('returns true when a clipPath is present', () => {
       const rect = new Rect({ width: 100, height: 100 });
       rect.clipPath = new Rect({ width: 50, height: 50 });
-      expect(rect.needsItsOwnCache()).toBe(true);
+      expect(rect.requiresContextIsolation()).toBe(true);
     });
     it('returns true when paintFirst is stroke and there is a shadow', () => {
       const rect = new Rect({ width: 100, height: 100 });
       rect.paintFirst = 'stroke';
       rect.stroke = 'black';
       rect.shadow = new Shadow({ color: 'green' });
-      expect(rect.needsItsOwnCache()).toBe(true);
+      expect(rect.requiresContextIsolation()).toBe(true);
     });
     it('returns false when paintFirst is stroke and there is no shadow', () => {
       const rect = new Rect({ width: 100, height: 100 });
       rect.paintFirst = 'stroke';
       rect.stroke = 'black';
       rect.shadow = null;
-      expect(rect.needsItsOwnCache()).toBe(false);
+      expect(rect.requiresContextIsolation()).toBe(false);
     });
     it('returns false when paintFirst is stroke but no stroke', () => {
       const rect = new Rect({ width: 100, height: 100 });
       rect.paintFirst = 'stroke';
       rect.stroke = '';
       rect.shadow = new Shadow({ color: 'green' });
-      expect(rect.needsItsOwnCache()).toBe(false);
+      expect(rect.requiresContextIsolation()).toBe(false);
     });
     it('returns false when paintFirst is stroke but no fill', () => {
       const rect = new Rect({ width: 100, height: 100 });
@@ -111,7 +111,7 @@ describe('Object', () => {
       rect.stroke = 'black';
       rect.fill = '';
       rect.shadow = new Shadow({ color: 'green' });
-      expect(rect.needsItsOwnCache()).toBe(false);
+      expect(rect.requiresContextIsolation()).toBe(false);
     });
   });
   describe('set method and dirty flag bubbling', () => {

--- a/src/shapes/Object/Object.ts
+++ b/src/shapes/Object/Object.ts
@@ -55,6 +55,7 @@ import type { SerializedObjectProps } from './types/SerializedObjectProps';
 import type { ObjectProps } from './types/ObjectProps';
 import { getDevicePixelRatio, getEnv } from '../../env';
 import { log } from '../../util/internals/console';
+import { canvasProvider } from '../../canvas/CanvasProvider';
 
 export type TCachedFabricObject<T extends FabricObject = FabricObject> = T &
   Required<
@@ -199,6 +200,7 @@ export class FabricObject<
    * @type boolean
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   _cacheContext: CanvasRenderingContext2D | null = null;
 
@@ -210,6 +212,7 @@ export class FabricObject<
    * @type HTMLCanvasElement
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare _cacheCanvas?: HTMLCanvasElement;
 
@@ -219,6 +222,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare cacheWidth?: number;
 
@@ -228,6 +232,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare cacheHeight?: number;
 
@@ -237,6 +242,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare zoomX?: number;
 
@@ -246,6 +252,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare zoomY?: number;
 
@@ -255,6 +262,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare cacheTranslationX?: number;
 
@@ -264,6 +272,7 @@ export class FabricObject<
    * @type number
    * @default undefined
    * @private
+   * @deprecated unused @todo remove
    */
   declare cacheTranslationY?: number;
 
@@ -274,15 +283,6 @@ export class FabricObject<
    * @private
    */
   declare group?: Group;
-
-  /**
-   * Indicate if the object is sitting on a cache dedicated to it
-   * or is part of a larger cache for many object ( a group for example)
-   * @type number
-   * @default undefined
-   * @private
-   */
-  declare ownCaching?: boolean;
 
   /**
    * Private. indicates if the object inside a group is on a transformed context or not
@@ -345,6 +345,7 @@ export class FabricObject<
   /**
    * Create a the canvas used to keep the cached copy of the object
    * @private
+   * @deprecated unused @todo remove
    */
   _createCacheCanvas() {
     this._cacheCanvas = createCanvasElement();
@@ -368,6 +369,7 @@ export class FabricObject<
    * @return {Object}.height height of canvas
    * @return {Object}.zoomX zoomX zoom value to unscale the canvas before drawing cache
    * @return {Object}.zoomY zoomY zoom value to unscale the canvas before drawing cache
+   * @deprecated unused @todo remove
    */
   _limitCacheSize(
     dims: TSize & { zoomX: number; zoomY: number; capped: boolean } & any
@@ -416,6 +418,7 @@ export class FabricObject<
    * @return {Object}.height height of canvas
    * @return {Object}.zoomX zoomX zoom value to unscale the canvas before drawing cache
    * @return {Object}.zoomY zoomY zoom value to unscale the canvas before drawing cache
+   * @deprecated unused @todo remove
    */
   _getCacheCanvasDimensions(): TCacheCanvasDimensions {
     const objectScale = this.getTotalObjectScaling(),
@@ -441,6 +444,7 @@ export class FabricObject<
    * returns true or false if canvas needed resize.
    * @private
    * @return {Boolean} true if the canvas has been resized
+   * @deprecated unused @todo remove
    */
   _updateCacheCanvas() {
     const canvas = this._cacheCanvas,
@@ -774,6 +778,56 @@ export class FabricObject<
     );
   }
 
+  requiresContextIsolation() {
+    if (
+      this.paintFirst === 'stroke' &&
+      !!this.shadow &&
+      this.hasFill() &&
+      this.hasStroke()
+    ) {
+      return true;
+    }
+    if (this.clipPath) {
+      return true;
+    }
+    return false;
+  }
+
+  renderInIsolation(
+    destination: CanvasRenderingContext2D,
+    forClipping = false
+  ) {
+    const isolatedContext = canvasProvider.request(destination.canvas);
+    isolatedContext.save();
+    this._setOpacity(isolatedContext);
+    this._setShadow(isolatedContext);
+    isolatedContext.setTransform(destination.getTransform());
+    this.transform(isolatedContext);
+    forClipping &&
+      this.absolutePositioned &&
+      destination.transform(...invertTransform(this.calcTransformMatrix()));
+    this._renderBackground(isolatedContext);
+    this._render(isolatedContext);
+    const { clipPath } = this;
+    if (clipPath) {
+      clipPath._set('canvas', this.canvas);
+      clipPath._transformDone = true;
+      clipPath.renderInIsolation(isolatedContext, true);
+    }
+    isolatedContext.restore();
+
+    destination.save();
+    if (forClipping) {
+      destination.globalCompositeOperation = this.inverted
+        ? 'destination-out'
+        : 'destination-in';
+    }
+    destination.setTransform(1, 0, 0, 1, 0, 0);
+    destination.drawImage(isolatedContext.canvas, 0, 0);
+    destination.restore();
+    isolatedContext.release();
+  }
+
   /**
    * Renders an object on a specified context
    * @param {CanvasRenderingContext2D} ctx Context to render on
@@ -792,45 +846,23 @@ export class FabricObject<
       return;
     }
     ctx.save();
-    this._setupCompositeOperation(ctx);
-    this.drawSelectionBackground(ctx);
-    this.transform(ctx);
-    this._setOpacity(ctx);
-    this._setShadow(ctx);
-    if (this.shouldCache()) {
-      this.renderCache();
-      (this as TCachedFabricObject).drawCacheOnCanvas(ctx);
+    ctx.globalCompositeOperation = this.globalCompositeOperation;
+    if (this.requiresContextIsolation()) {
+      this.renderInIsolation(ctx);
     } else {
-      this._removeCacheCanvas();
-      this.drawObject(ctx);
-      this.dirty = false;
+      this.drawSelectionBackground(ctx);
+      this._setOpacity(ctx);
+      this._setShadow(ctx);
+      this.transform(ctx);
+      this._renderBackground(ctx);
+      this._render(ctx);
     }
+    this.dirty = false;
     ctx.restore();
   }
 
   drawSelectionBackground(ctx: CanvasRenderingContext2D) {
     /* no op */
-  }
-
-  renderCache(options?: any) {
-    options = options || {};
-    if (!this._cacheCanvas || !this._cacheContext) {
-      this._createCacheCanvas();
-    }
-    if (this.isCacheDirty() && this._cacheContext) {
-      this.drawObject(this._cacheContext, options.forClipping);
-      this.dirty = false;
-    }
-  }
-
-  /**
-   * Remove cacheCanvas and its dimensions from the objects
-   */
-  _removeCacheCanvas() {
-    this._cacheCanvas = undefined;
-    this._cacheContext = null;
-    this.cacheWidth = 0;
-    this.cacheHeight = 0;
   }
 
   /**
@@ -864,29 +896,6 @@ export class FabricObject<
   }
 
   /**
-   * When set to `true`, force the object to have its own cache, even if it is inside a group
-   * it may be needed when your object behave in a particular way on the cache and always needs
-   * its own isolated canvas to render correctly.
-   * Created to be overridden
-   * since 1.7.12
-   * @returns Boolean
-   */
-  needsItsOwnCache() {
-    if (
-      this.paintFirst === 'stroke' &&
-      this.hasFill() &&
-      this.hasStroke() &&
-      !!this.shadow
-    ) {
-      return true;
-    }
-    if (this.clipPath) {
-      return true;
-    }
-    return false;
-  }
-
-  /**
    * Decide if the object should cache or not. Create its own cache level
    * objectCaching is a global flag, wins over everything
    * needsItsOwnCache should be used when the object drawing method requires
@@ -896,137 +905,7 @@ export class FabricObject<
    * @return {Boolean}
    */
   shouldCache() {
-    this.ownCaching =
-      this.needsItsOwnCache() ||
-      (this.objectCaching && (!this.parent || !this.parent.isOnACache()));
-    return this.ownCaching;
-  }
-
-  /**
-   * Check if this object will cast a shadow with an offset.
-   * used by Group.shouldCache to know if child has a shadow recursively
-   * @return {Boolean}
-   * @deprecated
-   */
-  willDrawShadow() {
-    return (
-      !!this.shadow && (this.shadow.offsetX !== 0 || this.shadow.offsetY !== 0)
-    );
-  }
-
-  /**
-   * Execute the drawing operation for an object clipPath
-   * @param {CanvasRenderingContext2D} ctx Context to render on
-   * @param {FabricObject} clipPath
-   */
-  drawClipPathOnCache(
-    ctx: CanvasRenderingContext2D,
-    clipPath: TCachedFabricObject
-  ) {
-    ctx.save();
-    // DEBUG: uncomment this line, comment the following
-    // ctx.globalAlpha = 0.4
-    if (clipPath.inverted) {
-      ctx.globalCompositeOperation = 'destination-out';
-    } else {
-      ctx.globalCompositeOperation = 'destination-in';
-    }
-    //ctx.scale(1 / 2, 1 / 2);
-    if (clipPath.absolutePositioned) {
-      const m = invertTransform(this.calcTransformMatrix());
-      ctx.transform(m[0], m[1], m[2], m[3], m[4], m[5]);
-    }
-    clipPath.transform(ctx);
-    ctx.scale(1 / clipPath.zoomX, 1 / clipPath.zoomY);
-    ctx.drawImage(
-      clipPath._cacheCanvas,
-      -clipPath.cacheTranslationX,
-      -clipPath.cacheTranslationY
-    );
-    ctx.restore();
-  }
-
-  /**
-   * Execute the drawing operation for an object on a specified context
-   * @param {CanvasRenderingContext2D} ctx Context to render on
-   * @param {boolean} forClipping apply clipping styles
-   */
-  drawObject(ctx: CanvasRenderingContext2D, forClipping?: boolean) {
-    const originalFill = this.fill,
-      originalStroke = this.stroke;
-    if (forClipping) {
-      this.fill = 'black';
-      this.stroke = '';
-      this._setClippingProperties(ctx);
-    } else {
-      this._renderBackground(ctx);
-    }
-    this._render(ctx);
-    this._drawClipPath(ctx, this.clipPath);
-    this.fill = originalFill;
-    this.stroke = originalStroke;
-  }
-
-  /**
-   * Prepare clipPath state and cache and draw it on instance's cache
-   * @param {CanvasRenderingContext2D} ctx
-   * @param {FabricObject} clipPath
-   */
-  _drawClipPath(ctx: CanvasRenderingContext2D, clipPath?: FabricObject) {
-    if (!clipPath) {
-      return;
-    }
-    // needed to setup a couple of variables
-    // path canvas gets overridden with this one.
-    // TODO find a better solution?
-    clipPath._set('canvas', this.canvas);
-    clipPath.shouldCache();
-    clipPath._transformDone = true;
-    clipPath.renderCache({ forClipping: true });
-    this.drawClipPathOnCache(ctx, clipPath as TCachedFabricObject);
-  }
-
-  /**
-   * Paint the cached copy of the object on the target context.
-   * @param {CanvasRenderingContext2D} ctx Context to render on
-   */
-  drawCacheOnCanvas(this: TCachedFabricObject, ctx: CanvasRenderingContext2D) {
-    ctx.scale(1 / this.zoomX, 1 / this.zoomY);
-    ctx.drawImage(
-      this._cacheCanvas,
-      -this.cacheTranslationX,
-      -this.cacheTranslationY
-    );
-  }
-
-  /**
-   * Check if cache is dirty
-   * @param {Boolean} skipCanvas skip canvas checks because this object is painted
-   * on parent canvas.
-   */
-  isCacheDirty(skipCanvas = false) {
-    if (this.isNotVisible()) {
-      return false;
-    }
-    if (
-      this._cacheCanvas &&
-      this._cacheContext &&
-      !skipCanvas &&
-      this._updateCacheCanvas()
-    ) {
-      // in this case the context is already cleared.
-      return true;
-    } else {
-      if (this.dirty || (this.clipPath && this.clipPath.absolutePositioned)) {
-        if (this._cacheCanvas && this._cacheContext && !skipCanvas) {
-          const width = this.cacheWidth! / this.zoomX!;
-          const height = this.cacheHeight! / this.zoomY!;
-          this._cacheContext.clearRect(-width / 2, -height / 2, width, height);
-        }
-        return true;
-      }
-    }
-    return false;
+    return this.objectCaching;
   }
 
   /**
@@ -1548,27 +1427,6 @@ export class FabricObject<
       this.top = y;
       this.originX = originX;
       this.originY = originY;
-    }
-  }
-
-  /**
-   * This callback function is called by the parent group of an object every
-   * time a non-delegated property changes on the group. It is passed the key
-   * and value as parameters. Not adding in this function's signature to avoid
-   * Travis build error about unused variables.
-   */
-  setOnGroup() {
-    // implemented by sub-classes, as needed.
-  }
-
-  /**
-   * Sets canvas globalCompositeOperation for specific object
-   * custom composition operation for the particular object can be specified using globalCompositeOperation property
-   * @param {CanvasRenderingContext2D} ctx Rendering canvas context
-   */
-  _setupCompositeOperation(ctx: CanvasRenderingContext2D) {
-    if (this.globalCompositeOperation) {
-      ctx.globalCompositeOperation = this.globalCompositeOperation;
     }
   }
 

--- a/src/shapes/Object/defaultValues.ts
+++ b/src/shapes/Object/defaultValues.ts
@@ -75,6 +75,7 @@ export const fabricObjectDefaultValues: Partial<
   visible: true,
   includeDefaultValues: true,
   excludeFromExport: false,
+  // TODO: removed as unused or set to false
   objectCaching: true,
   clipPath: undefined,
   inverted: false,

--- a/src/util/misc/planeChange.spec.ts
+++ b/src/util/misc/planeChange.spec.ts
@@ -63,8 +63,6 @@ describe('Plane Change', () => {
     const group2 = new Group();
     const obj = new FabricObject();
 
-    jest.spyOn(group, 'isOnACache').mockReturnValue(false);
-
     applyTransformToObject(obj, m);
     applyTransformToObject(group, m1);
     applyTransformToObject(group2, m2);

--- a/test/visual/clippath.js
+++ b/test/visual/clippath.js
@@ -30,37 +30,37 @@
     percentage: 0.06,
   });
 
-  function clipping01(canvas, callback) {
-    var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: 'transparent' });
-    var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
-    obj.clipPath = clipPath;
-    canvas.add(obj);
-    canvas.renderAll();
-    callback(canvas.lowerCanvasEl);
-  }
+  // function clipping01(canvas, callback) {
+  //   var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: 'transparent' });
+  //   var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
+  //   obj.clipPath = clipPath;
+  //   canvas.add(obj);
+  //   canvas.renderAll();
+  //   callback(canvas.lowerCanvasEl);
+  // }
 
-  tests.push({
-    test: 'A clippath ignores fill and stroke for drawing, not positioning',
-    code: clipping01,
-    golden: 'clipping01.png',
-    percentage: 0.06,
-  });
+  // tests.push({
+  //   test: 'A clippath ignores fill and stroke for drawing, not positioning',
+  //   code: clipping01,
+  //   golden: 'clipping01.png',
+  //   percentage: 0.06,
+  // });
 
-  function clipping02(canvas, callback) {
-    var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: '' });
-    var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
-    obj.clipPath = clipPath;
-    canvas.add(obj);
-    canvas.renderAll();
-    callback(canvas.lowerCanvasEl);
-  }
+  // function clipping02(canvas, callback) {
+  //   var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: '' });
+  //   var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
+  //   obj.clipPath = clipPath;
+  //   canvas.add(obj);
+  //   canvas.renderAll();
+  //   callback(canvas.lowerCanvasEl);
+  // }
 
-  tests.push({
-    test: 'falsy values for fill are handled',
-    code: clipping02,
-    golden: 'clipping01.png',
-    percentage: 0.06,
-  });
+  // tests.push({
+  //   test: 'falsy values for fill are handled',
+  //   code: clipping02,
+  //   golden: 'clipping01.png',
+  //   percentage: 0.06,
+  // });
 
   function clipping1(canvas, callback) {
     var zoom = 20;

--- a/test/visual/z_svg_export.js
+++ b/test/visual/z_svg_export.js
@@ -62,20 +62,20 @@
     }
   });
 
-  function clipping01(canvas, callback) {
-    var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: 'transparent' });
-    var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
-    obj.clipPath = clipPath;
-    canvas.add(obj);
-    toSVGCanvas(canvas, callback);
-  }
+  // function clipping01(canvas, callback) {
+  //   var clipPath = new fabric.Circle({ radius: 50, strokeWidth: 40, top: -50, left: -50, fill: 'transparent' });
+  //   var obj = new fabric.Rect({ top: 0, left: 0, strokeWidth: 0, width: 200, height: 200, fill: 'rgba(0,255,0,0.5)'});
+  //   obj.clipPath = clipPath;
+  //   canvas.add(obj);
+  //   toSVGCanvas(canvas, callback);
+  // }
 
-  tests.push({
-    test: 'A clippath ignores fill and stroke for drawing, not positioning',
-    code: clipping01,
-    golden: 'clipping01_SVG.png',
-    percentage: 0.06,
-  });
+  // tests.push({
+  //   test: 'A clippath ignores fill and stroke for drawing, not positioning',
+  //   code: clipping01,
+  //   golden: 'clipping01.png',
+  //   percentage: 0.06,
+  // });
 
   function clipping1(canvas, callback) {
     var zoom = 20;


### PR DESCRIPTION
<!--
        Hi there!
        Thanks for taking the time and putting the effort into making fabric better! 💖
        Take a look at /CONTRIBUTING.md for crucial instructions regarding local setup, testing etc.
        https://github.com/fabricjs/fabric.js/blob/master/CONTRIBUTING.md

        Adding tests that verify your fix and safeguard it from unwanted loss and changes is a MUST.

        Pull Requests are not always simple. Don't hesitate to ask for help (beware of [gotchas](http://fabricjs.com/fabric-gotchas) 😓).
        We appreciate your effort and would like the process to be productive and enjoyable.
        A strong community means a strong and better product for everyone.

        Each PR can introduce a single feature or change or fix a single bug
        Large refactors PR have been discussed before and probably splitted in steps
-->

## Description

<!-- Summarize the reasons of your changes and the meaning of your code. Why the code you are changing is wrong? why your is better? -->
<!-- If you are fixing a regression, please link the commit that introduced the bug -->
<!-- If you are proposing a feature, please link the discussion/issue where that was presented and discussed -->
<!-- Is this pullrequest a follow up from an open issue? if so please link the issue like the example below in addition to the summary -->
<!-- Related to #1234 -->

POC to drop object caching logic in favor of a better rendering approach

Ports parts of #8298 


Object caching and context isolation are 2 different things that were smashed together.
Object caching is a performance optimization targeting apparently panning and transforming (zooming invalidates the cache)
Context isolation is a necessity for supporting rendering operations in an object tree such as clipping a single object. Without it the operation is applied to the entire context, which is not desired.
Currently object caching covers most of the needs of a simple app in terms of context isolation. However if you move out of lines fabric's output is completely broken. e.g. shadows under a group with a clip path.
Also object caching has the blur issue because a clip path is unaware of it's parent, making the result of `getTotalObjectScaling` wrong always and the cache size off. That should be fixed regardless and of course I have a fix for it in #8298 .
Add to that a dev setting object caching to true/false and discovering to their surprise that fabric didn't comply and decided by itself what to do. This is the essence of the confusion and mixing of these 2 concepts.
Another issue I have been looking into is objects that are partially on screen. If they hold a cache it might be extremely wasteful instead of just rendering their visible part.

In this PR I aim to make the rendering logic simpler following a simple rule: Recursion **must** happen in a single method calling itself rather than a number of methods calling each other as it is currently.

- exposed `renderInIsolation` which renders the object at its final transform onto an isolated context and then draws that image onto the main context. For simplicity of the POC I didn't try (yet) to optimize the isolated context size.

- renamed `needsItOwnCache` to `requiresContextIsolation`
- disabled caching altogether - it can be reinstated if we want or completely refactored to use the isolation output. I think as a first step we should extract all the caching logic to a standalone so it is not on the Object class. If we understand it is a perf opt then it should not remain there. Half the code on Object is related to caching. 

This is a big step towards being able to invalidate a region in the canvas.

## In Action


https://github.com/fabricjs/fabric.js/assets/34343793/583d4e14-8df5-4171-ab64-570eda42e6e3

https://github.com/fabricjs/fabric.js/assets/34343793/2e172c91-6b29-4ee7-a94f-ef8e85f9120d




<!-- Add screenshots or recordings if necessary or requested -->
<!-- Are you proposing a performance change? show a some proof of performance -->
